### PR TITLE
Modifications to support multihoming by creating a new address type

### DIFF
--- a/AODVv2-pandoc-edits/AODVv2.mkd
+++ b/AODVv2-pandoc-edits/AODVv2.mkd
@@ -293,11 +293,9 @@ RouterClient.PrefixLength
 :   <vspace/>The length, in bits, of the routing prefix associated with the RouterClient.IPAddress.  If the prefix length is not equal to the address length of RouterClient.IPAddress, the AODVv2 router MUST participate in route discovery on behalf of all addresses within that prefix.
 RouterClient.Cost
 :   <vspace/>The cost associated with reaching this address or address range.
-
-A Router Client address MUST NOT be served by more than one AODVv2 router at any one time. To shift responsibility for a Router Client to
-a different AODVv2 router, correct AODVv2 routing behavior MUST be observed; The AODVv2 router adding the Router Client MUST wait for any
-existing routing information about this Router Client to be purged from the network, i.e., at least MAX_SEQNUM_LIFETIME since the last SeqNum
-update on the router that is removing this Router Client.
+RouterClient.Multihomed
+:   <vspace/>Whether or not the Router Client is served by more than
+             one AODVv2 router.
 
 
 ## Neighbor Set  {#nbrlist}
@@ -333,21 +331,30 @@ See [](#security-protection-application-rrepack) and [](#security-protection-app
 
 ## Sequence Numbers  {#seqnum}
 
-Sequence Numbers enable AODVv2 routers to determine the temporal order of route discovery
-messages, identifying stale routing information so that it can be discarded. The sequence
-number fulfills the same roles as the "Destination Sequence Number" of DSDV [](#Perkins94),
-and the AODV Sequence Number in [](#RFC3561).
+Sequence Numbers enable AODVv2 routers to determine the temporal order of
+route discovery information that originates from any single AODVv2 router, and
+thus to identify stale routing information so that it can be discarded.  The
+sequence number fulfills the same roles as the "Destination Sequence Number"
+of DSDV [](#Perkins94), and the AODV Sequence Number in [](#RFC3561).
+The sequence numbers from two different routers are not comparable.  Route
+discovery messages with sequence numbers belonging to two different routers
+cannot be compared to determine temporal ordering.
 
-<!-- If the router has multiple AODVv2 interfaces or IP addresses, it MAY maintain different sequence
-numbers for each interface or IP address, but the router MUST NOT use multiple sequence numbers
-for any one IP address.  All route messages created on behalf of Router
-Clients on a particular interface MUST include the sequence number associated with that Router Client. -->
+<!-- If the router has multiple AODVv2 interfaces or IP addresses, it MAY
+     maintain different sequence numbers for each interface or IP address, but
+     the router MUST NOT use multiple sequence numbers for any one IP address.
+     All route messages created on behalf of Router Clients on a particular
+     interface MUST include the sequence number associated with that Router
+     Client. -->
 
 Each AODVv2 router in the network MUST maintain its own sequence number. All RREQ and RREP messages created by an AODVv2 router include the router's sequence number, reported as a 16-bit unsigned integer. Each AODVv2 router MUST ensure that its sequence number is strictly increasing, and that it is incremented by one (1) whenever an RREQ or RREP is created, except when the sequence number is 65,535 (the maximum value of a 16-bit unsigned integer), in which case it MUST be reset to one (1) to achieve wrap around. The value zero (0) is reserved to indicate that the sequence number is unknown.
 
-An AODVv2 router MUST only attach its own sequence number to information about a route to one of its configured Router Clients, all route messages forwarded by other routers retain the originator's sequence number. 
+An AODVv2 router MUST only attach its own sequence number to information about a route to one of its configured Router Clients; all route messages forwarded by other routers retain the originator's sequence number. 
 
-To determine if newly received information is stale and therefore redundant, the sequence number attached to the information is compared to the sequence number of existing information about the same route. The comparison is carried out by subtracting the existing sequence number from the newly received sequence number, using unsigned arithmetic. The result of the subtraction is to be interpreted as a signed 16-bit integer. 
+To determine if newly received information is stale and therefore redundant
+compared to other information originated by the same router,
+the sequence number attached to the information is compared to the sequence
+number of existing information about the same route. The comparison is carried out by subtracting the existing sequence number from the newly received sequence number, using unsigned arithmetic. The result of the subtraction is to be interpreted as a signed 16-bit integer. 
 
 *  If the result is negative, the newly received information is considered older than the existing information and is considered stale and redundant and MUST therefore be discarded.
 *  If the result is positive, the newly received information is considered newer than the existing information and is not considered stale or redundant and MUST therefore be processed.
@@ -392,6 +399,9 @@ LocalRoute.Metric
 :   <vspace/>The cost of the route toward LocalRoute.Address expressed in units consistent with LocalRoute.MetricType.
 LocalRoute.State
 :   <vspace/>The last known state (Unconfirmed, Idle, Active, or Invalid) of the route.
+LocalRoute.SeqNoRtr	
+:   <vspace/>If nonzero, the IP address of the router that originated the	
+             Sequence Number for this route.
 
 There are four possible states for a LocalRoute:
 
@@ -450,8 +460,13 @@ RteMsg.RemoveTime
     to CurrentTime + MAX_SEQNUM_LIFETIME, whenever the RteMsg.OrigSeqNum of this entry is updated.
 RteMsg.Interface
 :   <vspace/>The interface on which the message was received.
+RteMsg.SeqNoRtr	
+:   <vspace/>If nonzero, the IP address of the router that originated the	
+             Sequence Number for this route.
 
-The Multicast Route Message Set is maintained so that no two entries have the same OrigPrefix, OrigPrefixLen, TargPrefix, and MetricType. See [](#suppress) for details about updating this set.
+The Multicast Route Message Set is maintained so that no two entries have
+the same OrigPrefix, OrigPrefixLen, TargPrefix, MetricType and SeqNoRtr.
+See [](#suppress) for details about updating this set.
 
 ## Route Error (RERR) Set  {#rerrtable}
 
@@ -746,7 +761,8 @@ to use and offers an improvement to existing information, as explained in [](#te
 If these checks pass, the Local Route Set MUST be updated according to [](#update_rte).
 
 In the processes below, RteMsg is used to denote the route message, AdvRte is used to denote the route contained within it, and LocalRoute
-denotes an existing entry in the Local Route Set which matches AdvRte on address, prefix length, and metric type.
+denotes an existing entry in the Local Route Set which matches AdvRte on address, prefix length, metric type, and SeqNoRtr.
+<!-- CEP TODO: Change to Originator as suggested by Vicky -->
 
 AdvRte has the following properties:
 
@@ -757,16 +773,18 @@ AdvRte has the following properties:
 * AdvRte.NextHop := RteMsg.IPSourceAddress (an address of the sending interface of the router from which the RteMsg was received)
 * AdvRte.MetricType := RteMsg.MetricType
 * AdvRte.Metric := RteMsg.Metric
-* AdvRte.Cost := Cost(R) using the cost function associated with the route's metric type,
-  i.e. Cost(R) = AdvRte.Metric + Cost(L), as described in [](#metrics), where L is the link from the
-  advertising router
-
+* AdvRte.Cost := Cost(R) using the cost function associated with the route's
+  metric type, i.e. Cost(R) = AdvRte.Metric + Cost(L), as described
+  in [](#metrics), where L is the link from the advertising router
+* AdvRte.SeqNoRtr := the IP address in the Address List of type	
+		 		SeqNoRtr if one exists, otherwise 0
 
 ### Evaluating Route Information  {#test}
 
 An incoming advertised route (AdvRte) is compared to existing LocalRoutes to determine whether the advertised route is to be used to update the AODVv2 Local Route Set. The incoming route information MUST be processed as follows:
 
-1.  Search for LocalRoutes in the Local Route Set matching AdvRte's address, prefix length and metric type
+1.  Search for LocalRoutes in the Local Route Set matching AdvRte's address,
+    prefix length, metric type, and SeqNoRtr
     *   If no matching LocalRoute exists, AdvRte MUST be used to update the Local Route Set and no further checks are required.
     *   If matching LocalRoutes are found, continue to Step 2.
 
@@ -798,7 +816,9 @@ If AdvRte is learned from an RREQ message, the link to the next hop neighbor may
 
 The route update is applied as follows:
 
-1.  If no existing entry in the Local Route Set matches AdvRte's address, prefix length and metric type, continue to Step 4 and create a new entry in the Local Route Set.
+1.  If no existing entry in the Local Route Set matches AdvRte's address,
+    prefix length, metric type and SeqNoRtr, continue to Step 4 and create
+    a new entry in the Local Route Set.
 
 1.  If two matching LocalRoutes exist in the Local Route Set, one is a valid route, and one is an Unconfirmed route, AdvRte may offer further improvement to the Unconfirmed route, or may offer an update to the valid route.
 
@@ -856,22 +876,29 @@ unnecessary signaling traffic and might generate unnecessary interference.
 
 Each AODVv2 router stores information about recently received route messages in the AODVv2 Multicast Route Message Set ([](#rtemsgtable)).
 
-Entries in the Multicast Route Message Set SHOULD be maintained for at least RteMsg_ENTRY_TIME after
-the last Timestamp update in order to account for long-lived RREQs traversing the network. An entry MUST
-be deleted when the sequence number is no longer valid, i.e., after MAX_SEQNUM_LIFETIME. Memory-constrained
-devices MAY remove the entry before this time.
+Entries in the Multicast Route Message Set SHOULD be maintained for at least
+RteMsg_ENTRY_TIME after the last Timestamp update in order to account for
+long-lived RREQs traversing the network. An entry MUST be deleted when the
+sequence number is no longer valid, i.e., after MAX_SEQNUM_LIFETIME.
+Memory-constrained devices MAY remove the entry before this time.
 
 Received route messages are tested against previously received route messages, and if determined to be
 redundant, forwarding or response can be avoided.
 
 To determine if a received message is redundant:
 
-1.  Search for an entry in the Multicast Route Message Set with the same OrigPrefix, OrigPrefixLen, TargPrefix, Interface and MetricType
+<!-- CEP TODO: Why is "Interface" in the following list?  -->
+1.  Search for an entry in the Multicast Route Message Set with the same OrigPrefix, OrigPrefixLen, TargPrefix, Interface, MetricType, and SeqNoRtr
     *   If there is no entry, the message is not redundant.
     *   If there is an entry, continue to Step 2.
 2.  Compare sequence numbers using the technique described in [](#seqnum)
-    *   Use OrigSeqNum of the entry for comparison.
-    *   If the entry has an older sequence number than the received message, the message is not redundant.
+    *   Use OrigSeqNum of the entry for comparison. If the incoming message
+        contains SeqNoRtr that is not comparable to the stored sequence number,
+        continue to Step 3.
+<!-- CEP TODO: Figure out how to label the steps and avoid hardcoded
+               references... -->
+    *   If the entry has an older sequence number than the received message,
+        the message is not redundant.
     *   If the entry has a newer sequence number than the received message, the message is redundant.
     *   If the entry has the same sequence number, continue to Step 3.
 3.  Compare the metric values
@@ -1044,7 +1071,16 @@ msg_hop_limit
 :   <vspace/>The remaining number of hops allowed for dissemination of the RREQ
     message.
 AddressList
-:   <vspace/>Contains OrigPrefix, from the Router Client Set entry which includes OrigAddr, the source address of the IP packet for which a route is requested, and TargPrefix, set to TargAddr, the destination address of the IP packet for which a route is requested.
+:   <vspace/>Contains:	
+	         OrigPrefix, from the Router Client entry which includes	
+	             OrigAddr, the source address of the IP packet for which
+                     a route is requested	
+                 TargPrefix, set to TargAddr, the destination	
+                     address of the IP packet for which a route is requested.	
+                 If RouterClient.SeqNoRtr is true, the IP address of OrigRtr
+                    -- i.e., the router that originated the Sequence Number
+                    for this RREQ.
+<!-- CEP TODO: Check terminology for OrigRtr -->
 PrefixLengthList
 :   <vspace/>Contains OrigPrefixLen, i.e., the length, in bits, of the prefix associated with
     the Router Client Set entry which includes OrigAddr. If omitted, the prefix length is equal
@@ -1080,6 +1116,8 @@ To generate the RREQ, the router (referred to as RREQ_Gen) follows this procedur
     *  If OrigAddr is part of an address range configured as a Router Client, set PrefixLengthList :=
        {RouterClient.PrefixLength, null}.
     *  Otherwise, omit PrefixLengthList.
+    *  If RouterClient.SeqNoRtr is nonzero, then add the router's own IP
+       address to AddressList, with AddressType SeqNoRtr.
 1.  For OrigSeqNum:
     *  Increment the router Sequence Number as specified in [](#seqnum).
     *  Set OrigSeqNum := router Sequence Number.
@@ -1172,8 +1210,15 @@ msg_hop_limit
 :   <vspace/>The remaining number of hops allowed for dissemination of the RREP
     message.
 AddressList
-:   <vspace/>Contains OrigPrefix and TargPrefix, the prefixes of the source and destination addresses
-    of the IP packet for which a route is requested.
+:   <vspace/>Contains:	
+	         OrigPrefix, from the Router Client entry which includes	
+	             OrigAddr, the source address of the IP packet for which
+                     a route is requested	
+                 TargPrefix, set to TargAddr, the destination	
+                     address of the IP packet for which a route is requested.	
+                 If RouterClient.SeqNoRtr is true, the IP address of OrigRtr
+                    -- i.e., the router that originated the Sequence Number
+                    for this RREP.
 PrefixLengthList
 :   <vspace/>Contains TargPrefixLen, i.e., the length, in bits, of the prefix associated with
     the Router Client Set entry which includes TargAddr. If omitted, the prefix length is equal
@@ -1211,6 +1256,8 @@ To generate the RREP, the router (also referred to as RREP_Gen) follows this pro
     *  If TargAddr is part of an address range configured as a Router Client, set PrefixLengthList :=
        {null, RouterClient.PrefixLength}.
     *  Otherwise, omit PrefixLengthList.
+    *  If RouterClient.SeqNoRtr is nonzero, then add the router's own IP
+       address to AddressList, with AddressType SeqNoRtr.
 1.  For the TargSeqNum:
     *  Increment the router Sequence Number as specified in [](#seqnum).
     *  Set TargSeqNum := router Sequence Number.
@@ -1232,17 +1279,18 @@ Upon receiving a Route Reply, an AODVv2 router performs the following steps:
 <!--
 1.  If this RREP does not correspond to an RREQ generated or forwarded in the last RREQ_WAIT_TIME, ignore for further processing.
 -->
-1. If the Multicast Route Message Set does not contain an entry where:
+1. Verify that the Multicast Route Message Set contains an entry where:
 
-* RteMsg.OrigPrefix == RREP.OrigPrefix
-* RteMsg.OrigPrefixLen == RREP.OrigPrefixLen
-* RteMsg.TargAddr exists within RREP.TargPrefix
-* RteMsg.OrigSeqNum <= RREP.OrigSeqNum
-* RteMsg.MetricType == RREP.MetricType
-* RteMsg.Timestamp > CurrentTime - RREQ_WAIT_TIME
-* RteMsg.Interface == The interface on which the RREP was received
+   * RteMsg.OrigPrefix == RREP.OrigPrefix
+   * RteMsg.OrigPrefixLen == RREP.OrigPrefixLen
+   * RteMsg.TargAddr exists within RREP.TargPrefix
+   * If RteMsg.OrigSeqNum and RREP.OrigSeqNum are comparable, then
+     RteMsg.OrigSeqNum <= RREP.OrigSeqNum
+   * RteMsg.MetricType == RREP.MetricType
+   * RteMsg.Timestamp > CurrentTime - RREQ_WAIT_TIME
+   * RteMsg.Interface == The interface on which the RREP was received
 
-ignore this RREP for further processing, since it does not correspond to a previously sent RREQ.
+Otherwise, ignore this RREP for further processing, since it does not correspond to a previously sent RREQ.
 
 
 1.  Update the Neighbor Set according to [](#nbrupdate)
@@ -1397,7 +1445,7 @@ destination is not reachable. There are three events that cause this response:
 
 *   When a link breaks, multiple LocalRoutes may become Invalid, and the RERR generated MAY contain multiple unreachable
     addresses. The RERR MUST include MetricTypeList. PktSource is omitted. All previously
-    Active LocalRoutes that used the broken link MUST be reported. The AddressList, PrefixLengthList, SeqNumList, and MetricTypeList
+    Active LocalRoutes that used the broken link MUST be reported. The AddressList, PrefixLengthList (if present), SeqNumList, and MetricTypeList
     will contain entries for each LocalRoute which has become Invalid. An RERR message is only sent if an Active LocalRoute
     becomes Invalid, though an AODVv2 router can also include Idle LocalRoutes that become Invalid if the configuration parameter
     ENABLE_IDLE_IN_RERR is set (see [](#other)).
@@ -1569,6 +1617,7 @@ Data                        Address Block
 -------------               ---------------
 OrigPrefix\/OrigPrefixLen   \<address\> + \<prefix-length\>
 TargPrefix\/TargPrefixLen   \<address\> + \<prefix-length\>
+SeqNoRtr/PrefixLen          \<address\> + \<prefix-length\>
 
 ### Address Block TLV Block
 Address Block TLVs are always associated with one or more addresses in the Address Block. The following
@@ -1611,6 +1660,7 @@ Data                        Address Block
 -------------               ---------------
 OrigPrefix\/OrigPrefixLen   \<address\> + \<prefix-length\>
 TargPrefix\/TargPrefixLen   \<address\> + \<prefix-length\>
+SeqNoRtr/PrefixLen          \<address\> + \<prefix-length\>
 
 ### Address Block TLV Block
 Address Block TLVs are always associated with one or more addresses in the Address Block. The following
@@ -1735,7 +1785,12 @@ When an AODVv2 router within the AODVv2 MANET wants to discover a route toward a
 
 The ENAR MUST respond to RREQ on behalf of all external network destinations, e.g., destinations not on the configured 191.0.2.0/24 network. The ENAR MUST NOT respond with a TargPrefix and TargPrefixLen which includes any of the networks configured as part of the AODVv2 network. Sending a Route Request for a gateway is not currently supported.
 
-RREQs for addresses inside the AODVv2 network, e.g. destinations on the configured 191.0.2.0/24 network, are handled using the standard processes described in [](#aodv_msgs). Note that AODvv2 does not support RREQs for prefixes that do not equal address length, but RREPs do advertise the prefix on which TargAddr resides.
+If more than one gateway is configured to serve the same external network,
+each such gateway MUST configure that external network as a Router Client	
+with value RouterClient.SeqNoRtr set equal to the gateway's IP address that
+serves the external network.
+
+RREQs for addresses inside the AODVv2 network, e.g. destinations on the configured 191.0.2.0/24 network, are handled using the standard processes described in [](#aodv_msgs). Note that AODVv2 does not support RREQs for prefixes that do not equal address length, but RREPs do advertise the prefix on which TargAddr resides.
 
 When an IP packet from an address on the external network destined for an address in the AODVv2 MANET reaches the
 ENAR, if the ENAR does not have a route toward that destination in its Routing Information Base, it will perform normal

--- a/AODVv2-pandoc-edits/appendices.mkd
+++ b/AODVv2-pandoc-edits/appendices.mkd
@@ -8,7 +8,8 @@ This section lists the changes between AODVv2 revisions ...-16.txt and ...-17.tx
 
 <!--
 
-This section lists the changes between AODVv2 revisions ...-15.txt and ...-16.txt.
+This section lists the changes between AODVv2 revisions ...-16.txt and
+...-17.txt.
 
 * Changed 'regeneration' language in favor of 'forwarding'.
 * Reintroduced use of msg-hop-limit in 5444 message header.
@@ -21,7 +22,11 @@ This section lists the changes between AODVv2 revisions ...-15.txt and ...-16.tx
 * Improved Sequence Number instructions
 * Changed 'Unknown' terminology to 'Heard'
 * Extended experiment description
-* Added detailed description of which steps to take when calculating and evaluating ICVs, particularly how to zero out the metric value
+* Added detailed description of which steps to take when calculating and
+  evaluating ICVs, particularly how to zero out the metric value
+* Enabled multihoming by creating new address type SeqNoRtr, along with
+  rules prohibiting comparison of sequence numbers from distinct	
+  multihoming routers per advertised prefix.
 
 This section lists the changes between AODVv2 revisions ...-14.txt and ...-15.txt.
 


### PR DESCRIPTION
Modifications to support multihoming by creating a new address type for the IP address that owns the sequence number associated with another address or address prefix.
